### PR TITLE
Fix: update Ubuntu release grabber URL to match domain redirect

### DIFF
--- a/utils/thirdparty/GrabUbuntuRelease/GrabUbuntuRelease.js
+++ b/utils/thirdparty/GrabUbuntuRelease/GrabUbuntuRelease.js
@@ -2,17 +2,17 @@ const cheerio = require('cheerio');
 const https = require('https');
 const fs = require('fs');
 
-const url = 'https://documentation.ubuntu.com/project/release-team/list-of-releases/';
+const url = 'https://ubuntu.com/project/docs/release-team/list-of-releases/';
 const template = './utils/thirdparty/GrabUbuntuRelease/_index.template.ubuntu.md';
 const target = './content/wiki/mirror-wiki/ubuntu-releases/_index.md';
 
 function parseURL(uri) {
   if (!uri) return '';
   if (uri.startsWith('http')) return uri;
-  if (uri.startsWith('/')) return 'https://documentation.ubuntu.com' + uri;
+  if (uri.startsWith('/')) return 'https://ubuntu.com' + uri;
   // 处理 Sphinx 的相对路径，去除 ../ 等
   const cleanUri = uri.replace(/^(\.\.\/)+/, '');
-  return 'https://documentation.ubuntu.com/project/release-team/list-of-releases/' + cleanUri;
+  return 'https://ubuntu.com/project/docs/release-team/list-of-releases/' + cleanUri;
 }
 
 function parseTable(html) {

--- a/utils/thirdparty/GrabUbuntuRelease/_index.template.ubuntu.md
+++ b/utils/thirdparty/GrabUbuntuRelease/_index.template.ubuntu.md
@@ -13,6 +13,6 @@ Ubuntu 发行镜像
 - x86_64
 
 ## 收录版本
-`生命期`内的 release 版本，以及旧 LTS 版本、core 版本等。发行代号以及版本号如下表，其余请参见 [Ubuntu Wiki](https://documentation.ubuntu.com/project/release-team/list-of-releases/)
+`生命期`内的 release 版本，以及旧 LTS 版本、core 版本等。发行代号以及版本号如下表，其余请参见 [Ubuntu Wiki](https://ubuntu.com/project/docs/release-team/list-of-releases/)
 
 ### 当前版本


### PR DESCRIPTION
  documentation.ubuntu.com now 301 redirects to ubuntu.com,
  causing GrabUbuntuRelease.js to fail when parsing the release table.
  Updated fetch URL, base URL for relative links, and template link.